### PR TITLE
Add option to skip dependencies

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -48,6 +48,8 @@ mkdir artifacts
 
 "%ProgramFiles(x86)%\MSBuild\14.0\Bin\csi.exe" .\tests\double-dependency.csx || goto :error
 
+"%ProgramFiles(x86)%\MSBuild\14.0\Bin\csi.exe" .\tests\dependency-error.csx -s || goto :error
+
 :: exit
 goto :EOF
 :error

--- a/src/internal/runner.csx
+++ b/src/internal/runner.csx
@@ -1,3 +1,4 @@
+#load "target-runner-options.csx"
 #load "target-runner.csx"
 #load "util.csx"
 #load "../simple-targets-target.csx"
@@ -15,8 +16,8 @@ public static class SimpleTargetsRunner
         var showUsage = false;
         var showDependencies = false;
         var showList = false;
-        var dryRun = false;
-        var color = true;
+
+        var options = new SimpleTargetsTargetRunnerOptions(targets, output);
 
         foreach (var option in args.Where(arg => arg.StartsWith("-", StringComparison.Ordinal)))
         {
@@ -34,10 +35,10 @@ public static class SimpleTargetsRunner
                     showList = true;
                     break;
                 case "-n":
-                    dryRun = true;
+                    options.DryRun = true;
                     break;
                 case "--no-color":
-                    color = false;
+                    options.Color = false;
                     break;
                 default:
                     throw new Exception($"Unknown option '{option}'.");
@@ -46,13 +47,13 @@ public static class SimpleTargetsRunner
 
         if (showUsage)
         {
-            output.Write(GetUsage(color));
+            output.Write(GetUsage(options.Color));
             return;
         }
 
         if (showDependencies)
         {
-            output.Write(GetDependencies(targets, color));
+            output.Write(GetDependencies(targets, options.Color));
             return;
         }
 
@@ -68,10 +69,10 @@ public static class SimpleTargetsRunner
             targetNames.Add("default");
         }
 
-        output.WriteLine(StartMessage(targetNames, dryRun, color));
+        output.WriteLine(StartMessage(targetNames, options.DryRun, options.Color));
 
-        SimpleTargetsTargetRunner.Run(targetNames, dryRun, targets, output, color);
+        SimpleTargetsTargetRunner.Run(targetNames, options);
 
-        output.WriteLine(SuccessMessage(targetNames, dryRun, color));
+        output.WriteLine(SuccessMessage(targetNames, options.DryRun, options.Color));
     }
 }

--- a/src/internal/runner.csx
+++ b/src/internal/runner.csx
@@ -16,7 +16,6 @@ public static class SimpleTargetsRunner
         var showUsage = false;
         var showDependencies = false;
         var showList = false;
-
         var options = new SimpleTargetsTargetRunnerOptions(targets, output);
 
         foreach (var option in args.Where(arg => arg.StartsWith("-", StringComparison.Ordinal)))
@@ -39,6 +38,9 @@ public static class SimpleTargetsRunner
                     break;
                 case "--no-color":
                     options.Color = false;
+                    break;
+                case "-s":
+                    options.RunDependencies = false;
                     break;
                 default:
                     throw new Exception($"Unknown option '{option}'.");

--- a/src/internal/target-runner-options.csx
+++ b/src/internal/target-runner-options.csx
@@ -14,6 +14,7 @@ public class SimpleTargetsTargetRunnerOptions
         this.Output = output;
         this.DryRun = false;
         this.Color = true;
+        this.RunDependencies = true;
     }
 
     public IDictionary<string, Target> Targets { get; }
@@ -23,4 +24,6 @@ public class SimpleTargetsTargetRunnerOptions
     public bool DryRun { get; set; }
 
     public bool Color { get; set; }
+
+    public bool RunDependencies { get; set; }
 }

--- a/src/internal/target-runner-options.csx
+++ b/src/internal/target-runner-options.csx
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static SimpleTargets;
+using static SimpleTargetsUtil;
+
+using System.Collections.Generic;
+
+public class SimpleTargetsTargetRunnerOptions
+{
+    public SimpleTargetsTargetRunnerOptions(IDictionary<string, Target>  targets, TextWriter output)
+    {
+        this.Targets = targets;
+        this.Output = output;
+        this.DryRun = false;
+        this.Color = true;
+    }
+
+    public IDictionary<string, Target> Targets { get; }
+
+    public TextWriter Output { get; }
+
+    public bool DryRun { get; set; }
+
+    public bool Color { get; set; }
+}

--- a/src/internal/target-runner.csx
+++ b/src/internal/target-runner.csx
@@ -1,3 +1,4 @@
+#load "target-runner-options.csx"
 #load "util.csx"
 #load "../simple-targets-target.csx"
 
@@ -9,20 +10,20 @@ using static SimpleTargetsUtil;
 
 public static class SimpleTargetsTargetRunner
 {
-    public static void Run(IList<string> targetNames, bool dryRun, IDictionary<string, Target> targets, TextWriter output, bool color)
+    public static void Run(IList<string> targetNames, SimpleTargetsTargetRunnerOptions options)
     {
         var targetsRan = new HashSet<string>();
         foreach (var name in targetNames)
         {
-            RunTarget(name, dryRun, targets, targetsRan, output, color);
+            RunTarget(name, targetsRan, options);
         }
     }
 
     private static void RunTarget(
-        string name, bool dryRun, IDictionary<string, Target> targets, ISet<string> targetsRan, TextWriter output, bool color)
+        string name, ISet<string> targetsRan, SimpleTargetsTargetRunnerOptions options)
     {
         Target target;
-        if (!targets.TryGetValue(name, out target))
+        if (!options.Targets.TryGetValue(name, out target))
         {
             throw new Exception($"Target \"{(name.Replace("\"", "\"\""))}\" not found.");
         }
@@ -34,14 +35,14 @@ public static class SimpleTargetsTargetRunner
 
         foreach (var dependency in target.Dependencies)
         {
-            RunTarget(dependency, dryRun, targets, targetsRan, output, color);
+            RunTarget(dependency, targetsRan, options);
         }
 
         if (target.Action != null)
         {
-            output.WriteLine(StartMessage(name, color));
+            options.Output.WriteLine(StartMessage(name, options.Color));
 
-            if (!dryRun)
+            if (!options.DryRun)
             {
                 try
                 {
@@ -49,12 +50,12 @@ public static class SimpleTargetsTargetRunner
                 }
                 catch (Exception ex)
                 {
-                    output.WriteLine(FailureMessage(name, ex, color));
+                    options.Output.WriteLine(FailureMessage(name, ex, options.Color));
                     throw new Exception($"Target \"{(name.Replace("\"", "\"\""))}\" failed.", ex);
                 }
             }
 
-            output.WriteLine(SuccessMessage(name, color));
+            options.Output.WriteLine(SuccessMessage(name, options.Color));
         }
     }
 }

--- a/src/internal/target-runner.csx
+++ b/src/internal/target-runner.csx
@@ -33,9 +33,12 @@ public static class SimpleTargetsTargetRunner
             return;
         }
 
-        foreach (var dependency in target.Dependencies)
+        if ( options.RunDependencies )
         {
-            RunTarget(dependency, targetsRan, options);
+            foreach (var dependency in target.Dependencies)
+            {
+                RunTarget(dependency, targetsRan, options);
+            }
         }
 
         if (target.Action != null)

--- a/src/internal/util.csx
+++ b/src/internal/util.csx
@@ -34,6 +34,7 @@ $@"{Cyan(color)}Usage: {Default(color)}{BrightYellow(color)}<script-runner> {Def
  {White(color)}-T          {Default(color)}Display the targets, then exit
  {White(color)}-n          {Default(color)}Do a dry run without executing actions
  {White(color)}--no-color  {Default(color)}Disable colored output
+ {White(color)}-s          {Default(color)}Run without executing targets' dependencies
 
 {Cyan(color)}targets: {Default(color)}A list of targets to run. If not specified, 'Default(color)' target will be run.
 

--- a/src/simple-targets-csx.nuspec
+++ b/src/simple-targets-csx.nuspec
@@ -20,6 +20,7 @@ See the quickstart at https://github.com/adamralph/simple-targets-csx#quickstart
   <files>
     <file src="internal/runner.csx"         target="internal/runner.csx" />
     <file src="internal/target-runner.csx"  target="internal/target-runner.csx" />
+    <file src="internal/target-runner-options.csx"  target="internal/target-runner-options.csx" />
     <file src="internal/util.csx"           target="internal/util.csx" />
     <file src="simple-targets-target.csx"   target="simple-targets-target.csx" />
     <file src="simple-targets.csx"          target="simple-targets.csx" />

--- a/tests/dependency-error.csx
+++ b/tests/dependency-error.csx
@@ -1,0 +1,11 @@
+#load "../artifacts/files/simple-targets.csx"
+
+using static SimpleTargets;
+
+var readVersionCount = 0;
+
+var targets = new TargetDictionary();
+targets.Add("default", DependsOn("throw"), () => {});
+targets.Add("throw", () => { throw new Exception("I fail, but am not required for the build"); });
+
+Run(Args, targets);


### PR DESCRIPTION
Fixes #92

The "options parameter" isn't strictly necessary, but the argument lists were getting unwieldy. 