### PR TITLE
Default target name in usage is incorrect.

### DIFF
--- a/src/internal/util.csx
+++ b/src/internal/util.csx
@@ -35,7 +35,7 @@ $@"{Cyan(color)}Usage: {Default(color)}{BrightYellow(color)}<script-runner> {Def
  {White(color)}-n          {Default(color)}Do a dry run without executing actions
  {White(color)}--no-color  {Default(color)}Disable colored output
 
-{Cyan(color)}targets: {Default(color)}A list of targets to run. If not specified, 'Default(color)' target will be run.
+{Cyan(color)}targets: {Default(color)}A list of targets to run. If not specified, 'default' target will be run.
 
 {Cyan(color)}Examples:{Default(color)}
   {BrightYellow(color)}csi.exe {Default(color)}build.csx


### PR DESCRIPTION
It was mangled during 31c1ae9099445d69a7e860b93dd465d2ecc2c1fe